### PR TITLE
vm: remove 1.4 redirect to index

### DIFF
--- a/source/.htaccess
+++ b/source/.htaccess
@@ -504,5 +504,5 @@ AddCharset utf-8 .atom .css .js .json .rss .vtt .xml
 
 # custom permanent redirects
 <IfModule mod_rewrite.c>
-  RewriteRule ^vm/instructions1.*$ /vm/index.html [R=301,L]
+  RewriteRule ^vm/instructions1_[2|3].*$ /vm/instructions1_4.html [R=301,L]
 </IfModule>


### PR DESCRIPTION
* vm/instructions1_4 are reachable now, closes #62
* vm/instructions1_[2|3] are redirect to 1_4

Requested-by: Steven Pousty
Signed-off-by: Jiri Fiala <jfiala@redhat.com>
Reviewed-by: João Gonçalves <jsvgoncalves@redhat.com>